### PR TITLE
Replace deprecated Cordova methods

### DIFF
--- a/src/ios/Sms.m
+++ b/src/ios/Sms.m
@@ -9,32 +9,32 @@
     CDVPluginResult* pluginResult = nil;
     NSString* phoneNumber = [command.arguments objectAtIndex:0];
     NSString* textMessage = [command.arguments objectAtIndex:1];
-    
+
     self.callbackID = command.callbackId;
-    
+
     if (![MFMessageComposeViewController canSendText]) {
         NSMutableDictionary* returnInfo = [NSMutableDictionary dictionaryWithCapacity:2];
-        
+
         [returnInfo setObject:@"SMS_FEATURE_NOT_SUPPORTED" forKey:@"code"];
         [returnInfo setObject:@"SMS feature is not supported on this device" forKey:@"message"];
-        
+
         pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:returnInfo];
-        
+
         [self.commandDelegate sendPluginResult:pluginResult callbackId:command.callbackId];
-        
+
         return;
     }
-    
+
     MFMessageComposeViewController *composeViewController = [[MFMessageComposeViewController alloc] init];
     composeViewController.messageComposeDelegate = self;
-    
+
     NSMutableArray *recipients = [[NSMutableArray alloc] init];
-    
+
     [recipients addObject:phoneNumber];
-    
+
     [composeViewController setBody:textMessage];
     [composeViewController setRecipients:recipients];
-    
+
     [self.viewController presentViewController:composeViewController animated:YES completion:nil];
 }
 
@@ -43,7 +43,7 @@
     BOOL succeeded = NO;
     NSString* errorCode = @"";
     NSString* message = @"";
-    
+
     switch(result) {
         case MessageComposeResultSent:
             succeeded = YES;
@@ -62,21 +62,23 @@
             errorCode = @"SMS_GENERAL_ERROR";
             break;
     }
-    
+
     [self.viewController dismissViewControllerAnimated:YES completion:nil];
-    
+
+    CDVPluginResult* pluginResult;
+
     if (succeeded == YES) {
-        [super writeJavascript:[[CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:message]
-                                toSuccessCallbackString:self.callbackID]];
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_OK messageAsString:message];
     } else {
         NSMutableDictionary* returnInfo = [NSMutableDictionary dictionaryWithCapacity:2];
-        
+
         [returnInfo setObject:errorCode forKey:@"code"];
         [returnInfo setObject:message forKey:@"message"];
-        
-        [super writeJavascript:[[CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:returnInfo]
-                                toErrorCallbackString:self.callbackID]];
+
+        pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR messageAsDictionary:returnInfo];
     }
+
+    [self.commandDelegate sendPluginResult:pluginResult callbackId:self.callbackID];
 }
 
 @end


### PR DESCRIPTION
Replace the methods that are deprecated in Cordova >= 3.6.3, as these will be fully removed in Cordova 4 and currently show warnings.
